### PR TITLE
docs: add practical multi-file website documentation for solo maintenance

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,131 +1,24 @@
-# Cachoeira das Araras - Sistema de Vouchers
+# Cachoeira das Araras — Sistema de Vouchers
 
-Sistema de gerenciamento de vouchers para Cachoeira das Araras.
+Este repositório contém o website de venda e gestão de vouchers da Cachoeira das Araras.
 
-## Arquitetura de Settings
+## Documentação principal
 
-O sistema de configurações foi refatorado para usar uma arquitetura DAL (Data Access Layer) centralizada:
+A documentação foi organizada em múltiplos arquivos na pasta [`docs/`](./docs/README.md), com foco em manutenção por solo dev:
 
-### Estrutura
+- visão do produto e fluxos;
+- arquitetura técnica;
+- mapa de rotas;
+- modelo de dados e settings;
+- playbook de manutenção.
 
-1. **DAL (`src/lib/settings.ts`)**
-   - `getSetting(key)` - Busca um setting individual com tipo inferido
-   - `setSetting(key, value)` - Atualiza um setting com tipo seguro
-   - `getAllSettings()` - **Novo**: Busca todos os settings de uma vez (usado internamente pelo tRPC)
+## Comandos
 
-2. **tRPC Router (`src/server/api/routers/settings.ts`)**
-   - `settings.getAll` - Única query tRPC que retorna todas as configurações como um objeto tipado
-   - Substituiu todas as queries individuais para melhor performance
-
-3. **Server Actions (`src/app/admin/dashboard/configuracoes/actions.ts`)**
-   - `getAllSettings()` - Usa a DAL para buscar todos os settings em formato de array
-   - `updateSetting()` - Atualiza um setting específico
-   - `getSettingValue()` - Busca um setting específico
-
-4. **Components**
-   - `voucher-form.tsx` - Usa `api.settings.getAll.useQuery()` para aplicar configurações dinâmicas
-   - `price-table.tsx` - Componente estático que exibe preços (usa env vars para display)
-   - `configuracoes/page.tsx` - Server component que exibe e gerencia settings
-   - `voucher-form-test.tsx` - Modo teste usa o mesmo padrão que form principal
-
-### Benefícios
-
-- ✅ Uma única query tRPC em vez de múltiplas queries paralelas
-- ✅ Melhor performance (menos round trips)
-- ✅ Código mais maintível com DAL centralizada
-- ✅ Type-safe end-to-end
-- ✅ Defaults aplicados automaticamente
-
-## Funcionalidades
-
-### Admin Dashboard
-
-- **Configurações**: Interface para gerenciar configurações do sistema
-  - Preços de vouchers (normal e piscina)
-  - Limites de dias e pessoas
-  - Mensagens do sistema
-  - Controles de habilitação de compras
-- **Vendas**: Relatórios e gestão de vendas
-- **Vouchers**: Gerenciamento de vouchers criados
-
-### Sistema de Vouchers
-
-- Compra de vouchers com diferentes opções
-- Validação de vouchers
-- Integração com Mercado Pago
-- Sistema de referência
-
-### Test Mode
-
-- Acesse `/test__` para testar o fluxo de compra em modo de teste
-- Nome do comprador é preenchido automaticamente com "--TESTE--"
-- Preço fixo de R$ 0,01 independente da quantidade selecionada
-- Cria vouchers reais com preço de teste no Mercado Pago
-
----
-
-# Create T3 App
-
-This is a [T3 Stack](https://create.t3.gg/) project bootstrapped with `create-t3-app`.
-
-## What's next? How do I make an app with this?
-
-We try to keep this project as simple as possible, so you can start with just the scaffolding we set up for you, and add additional things later when they become necessary.
-
-If you are not familiar with the different technologies used in this project, please refer to the respective docs. If you still are in the wind, please join our [Discord](https://t3.gg/discord) and ask for help.
-
-- [Next.js](https://nextjs.org)
-- [NextAuth.js](https://next-auth.js.org)
-- [Prisma](https://prisma.io)
-- [Drizzle](https://orm.drizzle.team)
-- [Tailwind CSS](https://tailwindcss.com)
-- [tRPC](https://trpc.io)
-
-## Learn More
-
-To learn more about the [T3 Stack](https://create.t3.gg/), take a look at the following resources:
-
-- [Documentation](https://create.t3.gg/)
-- [Learn the T3 Stack](https://create.t3.gg/en/faq#what-learning-resources-are-currently-available) — Check out these awesome tutorials
-
-You can check out the [create-t3-app GitHub repository](https://github.com/t3-oss/create-t3-app) — your feedback and contributions are welcome!
-
-## How do I deploy this?
-
-Follow our deployment guides for [Vercel](https://create.t3.gg/en/deployment/vercel), [Netlify](https://create.t3.gg/en/deployment/netlify) and [Docker](https://create.t3.gg/en/deployment/docker) for more information.
-
-## Facebook Pixel & Google Analytics Integration
-
-This project includes conversion tracking for both Facebook Pixel and Google Analytics when payment events occur. When a payment is approved through MercadoPago, conversion events are automatically sent to both platforms.
-
-### Environment Variables Required
-
-Add these environment variables to your deployment:
-
-```env
-# Facebook Pixel (required)
-FACEBOOK_PIXEL_ID=your_pixel_id_here
-FACEBOOK_ACCESS_TOKEN=your_access_token_here
-
-# Google Analytics 4 (optional)
-GOOGLE_ANALYTICS_MEASUREMENT_ID=G-XXXXXXXXXX
-GOOGLE_ANALYTICS_API_SECRET=your_api_secret_here
+```bash
+pnpm install
+pnpm dev
+npm run lint
+npm run build
 ```
 
-### How it works
-
-1. When a webhook is received from MercadoPago for an approved payment
-2. The system validates the payment status and extracts the payer's email
-3. **Facebook Pixel**:
-   - Email is hashed using SHA256 for privacy compliance
-   - A "Purchase" event is sent to Facebook's Conversions API with transaction details
-4. **Google Analytics**:
-   - A "purchase" event is sent to Google Analytics 4 Measurement Protocol
-   - Includes transaction details, item information, and conversion tracking
-
-### Files involved
-
-- `src/lib/utils/webhook-pixel.ts` - Main utility for sending Facebook Pixel and Google Analytics events
-- `src/app/api/webhook/route.ts` - Webhook endpoint that triggers the conversion events
-- `src/env.js` - Environment variable configuration
-- `test-simple.js` - Test file for validating both integrations
+> Observação: se não existir script `type-check` no `package.json`, rode `pnpm exec tsc --noEmit` como equivalente local.

--- a/docs/01-product-overview.md
+++ b/docs/01-product-overview.md
@@ -1,0 +1,49 @@
+# 01 — Visão Geral do Produto
+
+## O que este app faz
+
+O projeto é um site de vendas e gestão de vouchers da Cachoeira das Araras. Ele cobre:
+
+- Compra de voucher no front público.
+- Pagamento via Mercado Pago.
+- Retorno e acompanhamento do pagamento.
+- Emissão/visualização do voucher.
+- Validação de voucher na área admin.
+- Painéis operacionais para acompanhar vouchers do dia, vendas e configurações.
+
+## Perfis de uso
+
+### 1) Cliente final (visitante)
+
+- Entra no site público.
+- Seleciona quantidades (inteira/meia, com e sem piscina).
+- Informa nome/telefone e data pretendida.
+- Vai para pagamento Mercado Pago.
+- Após pagamento, acessa a página com dados do voucher.
+
+### 2) Operação interna (admin)
+
+- Consulta vouchers esperados para hoje.
+- Valida código de voucher na entrada.
+- Marca voucher como utilizado (`redeemed`).
+- Ajusta configurações sem deploy (preços, limites, mensagens e flags de venda).
+
+## Fluxo principal ponta-a-ponta
+
+1. Front cria intenção de compra e um código curto do voucher.
+2. Sistema cria `preference` no Mercado Pago e salva voucher com status inicial.
+3. Cliente paga no checkout do Mercado Pago.
+4. Webhook confirma pagamento assinado e atualiza voucher para válido.
+5. Cliente vê página de pagamento/voucher.
+6. Time do local valida e consome voucher no admin.
+
+## Regras de negócio importantes
+
+- Voucher só deve ser aceito quando pagamento está confirmado.
+- Status de voucher é central para operação (`pending`, `valid`, `redeemed`, `expired`).
+- Há soft delete para registros expirados/pendentes antigos.
+- Existem feature flags para habilitar/desabilitar tipos de compra sem alterar código.
+
+## Modo de teste
+
+Existe uma rota de teste para fluxo de compra com preço simbólico, útil para validar integração sem gerar vendas reais de valor normal.

--- a/docs/02-architecture-and-stack.md
+++ b/docs/02-architecture-and-stack.md
@@ -1,0 +1,60 @@
+# 02 — Arquitetura e Stack Técnica
+
+## Stack principal
+
+- **Next.js (App Router)** para páginas e API routes.
+- **React + TypeScript** na UI.
+- **tRPC** para camada de API tipada entre client e server.
+- **Prisma** para acesso ao banco PostgreSQL.
+- **Mercado Pago SDK/API** para checkout e pagamentos.
+- **Tailwind CSS + Radix UI** para interface.
+
+## Organização de diretórios (visão prática)
+
+- `src/app/` — páginas, layouts e rotas API (App Router).
+- `src/app/_components/` — componentes de domínio do app (voucher, compra, etc.).
+- `src/server/api/routers/` — routers tRPC (voucher, settings, mercadopago etc.).
+- `src/lib/` — utilitários, lógica de negócio e integrações.
+- `prisma/schema.prisma` — modelo de dados.
+
+## Como as camadas conversam
+
+1. **UI client** usa hooks `api.*` (tRPC React).
+2. Hooks chamam procedures em `src/server/api/routers/*`.
+3. Procedures usam Prisma (`ctx.db`) e integrações externas.
+4. Algumas integrações externas também vivem em API Routes (`src/app/api/*`), por exemplo webhook.
+
+## Desenho dos fluxos críticos
+
+### Fluxo de compra
+
+- `voucher-form` coleta dados.
+- Chama `mercadopago.create` para gerar preferência.
+- Cria voucher no banco (`voucher.create`) com `preference_id`.
+- Redireciona para `init_point` do Mercado Pago.
+
+### Fluxo de confirmação de pagamento
+
+- Mercado Pago envia webhook para `/api/webhook`.
+- Assinatura do webhook é validada via HMAC.
+- Sistema consulta pagamento e atualiza voucher para status válido quando aprovado.
+- Integrações de conversão (Meta/Google Ads) são disparadas sem bloquear a confirmação.
+
+### Fluxo operacional (uso do voucher)
+
+- Admin consulta voucher por código.
+- Se válido, pode marcar como utilizado (`redeemed`) e invalidar reutilização.
+
+## Padrões já adotados
+
+- Settings centralizadas em DAL (`src/lib/settings.ts`) com defaults.
+- Query única para settings (`settings.getAll`) para reduzir múltiplas requisições.
+- Revalidação de página de configurações após update por server action.
+
+## Débitos técnicos visíveis
+
+- Há rotas/arquivos de teste no app router (`test__`, `tests_iE72e7789D3`, etc.).
+- Existe mistura de português/inglês em nomes e mensagens.
+- Algumas tipagens/nomes poderiam ser padronizados (ex.: typos como `getPrefence`).
+
+Nada disso impede operação, mas vale manter no backlog para limpeza gradual.

--- a/docs/03-routes-and-pages.md
+++ b/docs/03-routes-and-pages.md
@@ -1,0 +1,38 @@
+# 03 — Mapa de Rotas e Páginas
+
+## Rotas públicas (cliente)
+
+- `/` — home com carrossel, informações e módulo de compra.
+- `/galeria` — galeria de imagens.
+- `/pagamento` — página de retorno pós-checkout (interpreta status e parâmetros).
+- `/pagamento/aprovado` — página de confirmação de pagamento aprovado.
+- `/voucher` — página de exibição do voucher com base em `code` e `pid` na query.
+- `/comprar` — redireciona para `/` (rota legada).
+
+## Rotas admin
+
+- `/admin` — validação de vouchers + painel de vouchers do dia.
+- `/admin/dashboard` — visão analítica/operacional do dia.
+- `/admin/dashboard/configuracoes` — gerenciamento de settings do site.
+- `/admin/dashboard/vendas` — área de vendas.
+- `/admin/dashboard/vouchers` — visão de vouchers.
+- `/admin/dashboard/referencias` — dados de referência/referrer.
+- `/admin/tabela` — tabela detalhada de vouchers.
+- `/admin/hoje` — visão focada em hoje.
+
+## API Routes
+
+- `/api/trpc/[trpc]` — endpoint central do tRPC.
+- `/api/webhook` — webhook Mercado Pago (validação assinatura + atualização voucher).
+- `/api/cron` — rotinas de expiração/limpeza de vouchers (protegida por bearer token).
+- `/api/auth/[...nextauth]` — NextAuth handler.
+- `/api/pagamento/aprovado` — endpoint simples para validar params de callback.
+
+## Rotas utilitárias/teste
+
+- `/(client)/test__`
+- `/(client)/tests_iE72e7789D3`
+- `/image-test`
+- `/qr`
+
+Sugestão: manter documentadas, mas considerar remover/ocultar em produção se não forem necessárias para operação.

--- a/docs/04-data-model-and-settings.md
+++ b/docs/04-data-model-and-settings.md
@@ -1,0 +1,68 @@
+# 04 — Modelo de Dados e Configurações
+
+## Entidades principais (Prisma)
+
+### `Voucher`
+
+Campos essenciais para operação:
+
+- `code` (único): identificador curto usado no atendimento.
+- `status`: estado do fluxo (`pending`, `valid`, `redeemed`, `expired`).
+- `valid`: flag booleana auxiliar de validade.
+- `preference_id`: id da preferência do Mercado Pago.
+- `payment_id`: id do pagamento confirmado (quando houver).
+- `expires_at`: data planejada de uso/expiração.
+- `deletedAt`: soft delete.
+
+Também guarda quantidades e preço final para rastreabilidade da compra.
+
+### `SiteSetting`
+
+Tabela de configuração dinâmica do sistema:
+
+- chave (`key`) + tipo (`type`) + valor em colunas tipadas.
+- permite alterar comportamento sem redeploy.
+
+### `Referrer`
+
+Relaciona voucher com origem/referrer para acompanhamento de aquisição.
+
+## Máquina de estados do voucher (prática)
+
+- `pending`: criado, pagamento não confirmado.
+- `valid`: pagamento aprovado, pode ser utilizado.
+- `redeemed`: já consumido na entrada.
+- `expired`: expirou sem uso.
+
+### Regras operacionais associadas
+
+- webhook aprovado move para `valid` e define `valid: true`.
+- validação admin move para `redeemed` e `valid: false`.
+- cron move vouchers vencidos para `expired` quando ainda válidos.
+- cron aplica soft delete em pendentes vencidos.
+
+## Sistema de settings
+
+Acesso centralizado via `src/lib/settings.ts`:
+
+- `getSetting(key)`
+- `setSetting(key, value)`
+- `getAllSettings()`
+
+### Chaves existentes relevantes
+
+- Preço: `voucher.price`, `voucher.pool.price`.
+- Limites de quantidade por tipo.
+- Flags de habilitação de compra por modalidade.
+- Mensagens textuais (`top.message`, `form.message`).
+- Janela de datas (`max.intended.days`, `disabled.days`).
+
+## Onde settings impactam o front
+
+Formulário de compra consome `api.settings.getAll.useQuery()` e aplica:
+
+- bloqueio de tipos de compra desativados;
+- mensagens dinâmicas;
+- regras de calendário e limites.
+
+Isso reduz hardcode de regra no front e permite ajustes operacionais rápidos.

--- a/docs/05-maintenance-playbook.md
+++ b/docs/05-maintenance-playbook.md
@@ -1,0 +1,66 @@
+# 05 — Playbook de Manutenção (Solo Dev)
+
+## Rotina de desenvolvimento local
+
+1. Instalar dependências: `pnpm install`
+2. Subir ambiente: `pnpm dev`
+3. Verificações antes de subir mudanças:
+   - `npm run lint`
+   - `npm run type-check` (ou equivalente local com `tsc --noEmit` se o script não existir)
+   - `npm run build`
+
+## Tarefas comuns e onde mexer
+
+## 1) Alterar preço e disponibilidade de venda
+
+- Primeiro tente em `/admin/dashboard/configuracoes`.
+- Se precisar novo parâmetro, adicionar chave em:
+  - tipo de chave em `src/lib/settings.ts`;
+  - formulário de configurações em `src/app/admin/dashboard/configuracoes/page.tsx`.
+
+## 2) Ajustar regras do formulário de compra
+
+- Arquivo principal: `src/app/_components/voucher-form.tsx`.
+- Utilitários de cálculo/formatação em `src/lib/utils/utils.ts` e `src/lib/voucher/*`.
+
+## 3) Alterar comportamento de pagamento
+
+- Criação de preferência: `src/server/api/routers/mercadopago.ts`.
+- Retorno e exibição para usuário: `src/app/(client)/pagamento/*` e `src/app/(client)/voucher/page.tsx`.
+- Confirmação assíncrona oficial: `src/app/api/webhook/route.ts`.
+
+## 4) Ajustar vencimento e limpeza automática
+
+- Job: `src/app/api/cron/route.ts`.
+- Token de proteção: `CRON_SECRET`.
+
+## Checklist para mudanças seguras
+
+Antes de merge/deploy:
+
+- [ ] Fluxo de compra completo testado (criação -> checkout -> retorno).
+- [ ] Webhook funcionando no ambiente alvo (assinatura válida).
+- [ ] Admin consegue validar voucher e consumi-lo.
+- [ ] Cron de expiração executando com autorização correta.
+- [ ] Lint/build verdes.
+
+## Variáveis de ambiente críticas
+
+- Banco e app: `DATABASE_URL`, `URL`.
+- Auth e sessão: `NEXTAUTH_SECRET`, `NEXTAUTH_URL`.
+- Pagamento: `MERCADOPAGO_TOKEN`, `WEBHOOK_URL`.
+- Manutenção: `CRON_SECRET`.
+- Tracking opcional: Meta/Google Ads.
+
+## Riscos conhecidos para futuras mudanças
+
+- Alterar formato de `code` sem revisar validações quebra busca/consulta.
+- Alterar status sem alinhar webhook/admin/cron pode criar inconsistência.
+- Mudar estrutura de `SiteSetting` exige cuidado com defaults no DAL.
+
+## Sugestões de evolução incremental
+
+- Consolidar páginas de teste e remover rotas não usadas em produção.
+- Criar script oficial `type-check` no `package.json`.
+- Adicionar testes e2e mínimos para fluxo de compra e validação de voucher.
+- Padronizar nomenclatura (pt/en) para facilitar manutenção de longo prazo.

--- a/docs/06-optimization-implementation-plan.md
+++ b/docs/06-optimization-implementation-plan.md
@@ -1,0 +1,236 @@
+# 06 — Plano de Implementação das Otimizações
+
+Documento prático para implementação individual. Cada item descreve **o que mudar**, **onde mudar** e **qual ganho esperado**.
+
+---
+
+## Ordem de execução recomendada
+
+1. Segurança e integridade (itens 1–3)
+2. Escalabilidade backend (itens 4–6)
+3. Performance frontend e organização (itens 7–9)
+4. Qualidade de release/produção (item 10)
+
+---
+
+## 1) Autenticação admin segura
+
+**O que será modificado**
+- Substituir autenticação por cookie simples/senha hardcoded por sessão segura.
+
+**Arquivos principais**
+- `src/app/lib.ts`
+- `src/app/admin/layout.tsx`
+- `src/server/auth.ts`
+- (se necessário) middleware/guards para `/admin/*`
+
+**Implementação (resumo)**
+- Remover senha fixa e usar segredo em variável de ambiente (hash).
+- Exigir sessão válida para acesso admin.
+- Configurar cookie de sessão com `httpOnly`, `secure`, `sameSite`.
+
+**Melhora esperada**
+- Reduz risco de acesso indevido ao admin.
+- Maior segurança de produção e governança de acesso.
+
+---
+
+## 2) Endurecer autorização de tRPC
+
+**O que será modificado**
+- Procedures sensíveis deixarão de ser públicas.
+
+**Arquivos principais**
+- `src/server/api/trpc.ts`
+- `src/server/api/routers/voucher.ts`
+- `src/server/api/routers/notification.ts`
+- `src/server/api/routers/settings.ts`
+
+**Implementação (resumo)**
+- Migrar mutações sensíveis para `protectedProcedure`.
+- Manter públicas apenas operações necessárias ao fluxo de compra.
+- Padronizar retorno de erro com `TRPCError`.
+
+**Melhora esperada**
+- Menor superfície de ataque.
+- Menor chance de alteração indevida de vouchers/settings.
+
+---
+
+## 3) Webhook robusto e idempotente
+
+**O que será modificado**
+- Validação de webhook com regras estritas e sem fallback inseguro.
+
+**Arquivos principais**
+- `src/app/api/webhook/route.ts`
+- `src/server/api/routers/voucher.ts` (suporte a idempotência se necessário)
+
+**Implementação (resumo)**
+- Remover fallback de segredo (`your-secret-key`).
+- Validar obrigatoriedade de headers e parâmetros.
+- Garantir processamento idempotente por `payment_id`/`code`.
+- Logar eventos e falhas de forma rastreável.
+
+**Melhora esperada**
+- Menor risco de fraude/processamento duplo.
+- Fluxo de pagamento mais estável em produção.
+
+---
+
+## 4) Paginação e filtros no servidor (admin)
+
+**O que será modificado**
+- Listagens admin deixarão de carregar tudo no client.
+
+**Arquivos principais**
+- `src/server/api/routers/voucher.ts`
+- `src/app/admin/dashboard/vouchers/page.tsx`
+- `src/app/admin/tabela/data-table.tsx`
+- `src/app/admin/tabela/voucher-table.tsx`
+
+**Implementação (resumo)**
+- Criar query paginada (`take/skip` ou cursor) com filtros (status, busca, período).
+- Retornar total e página atual.
+- Adaptar UI para paginação server-side.
+
+**Melhora esperada**
+- Escala melhor com crescimento de dados.
+- Menor uso de memória e CPU no navegador.
+
+---
+
+## 5) Prisma unificado no cron
+
+**O que será modificado**
+- Cron deixará de instanciar `PrismaClient` localmente.
+
+**Arquivos principais**
+- `src/app/api/cron/route.ts`
+- `src/server/db.ts`
+
+**Implementação (resumo)**
+- Reutilizar cliente Prisma singleton do projeto.
+- Registrar quantos vouchers foram atualizados/deletados em cada execução.
+
+**Melhora esperada**
+- Menos risco de conexões excedentes.
+- Operação de cron mais previsível.
+
+---
+
+## 6) Cache/invalidação para settings
+
+**O que será modificado**
+- Política explícita para reduzir leituras repetidas de configuração.
+
+**Arquivos principais**
+- `src/lib/settings.ts`
+- `src/server/api/routers/settings.ts`
+- `src/app/admin/dashboard/configuracoes/actions.ts`
+
+**Implementação (resumo)**
+- Adicionar cache curto para `getAllSettings`.
+- Invalidar cache após update de configuração.
+- Padronizar uso de settings no front.
+
+**Melhora esperada**
+- Menor latência e menos carga no banco.
+- Atualização consistente de regras operacionais.
+
+---
+
+## 7) Redução de re-render e listeners frágeis
+
+**O que será modificado**
+- Ajustes em componentes com risco de re-render e listeners globais.
+
+**Arquivos principais**
+- `src/app/_components/voucher-form.tsx`
+- `src/app/admin/tabela/voucher-table.tsx`
+
+**Implementação (resumo)**
+- Remover `window.onresize` global e usar `useEffect` com cleanup.
+- Estabilizar dependências de `useEffect` no formulário.
+- Extrair hooks utilitários reutilizáveis.
+
+**Melhora esperada**
+- Menos bugs de UI e melhor fluidez.
+- Comportamento mais previsível em mobile/desktop.
+
+---
+
+## 8) Consolidar domínio de pagamento
+
+**O que será modificado**
+- Remover duplicidade e padronizar nomenclatura/fluxo.
+
+**Arquivos principais**
+- `src/server/api/routers/mercadopago.ts`
+- `src/app/(client)/pagamento/page.tsx`
+- `src/app/(client)/pagamento/aprovado/page.tsx`
+- `src/app/(client)/voucher/page.tsx`
+- `src/lib/mercadopago/*`
+
+**Implementação (resumo)**
+- Corrigir typo `getPrefence` e eliminar duplicações.
+- Centralizar fetch e normalização de `payment/preference` em serviço único.
+
+**Melhora esperada**
+- Menor custo de manutenção.
+- Menos inconsistências entre páginas de pagamento.
+
+---
+
+## 9) Estratégia de imagens e LCP
+
+**O que será modificado**
+- Revisar uso de `images.unoptimized` global e pipeline de assets.
+
+**Arquivos principais**
+- `next.config.js`
+- `src/app/_components/image_carousel.tsx`
+- `src/app/_components/swiper-carousel/mini-image-carousel.tsx`
+- `public/images/*`
+
+**Implementação (resumo)**
+- Avaliar otimização seletiva de imagens.
+- Padronizar dimensões, compressão e formatos modernos.
+- Manter prioridade apenas para imagens críticas.
+
+**Melhora esperada**
+- Melhor LCP e experiência inicial do usuário.
+- Uso de banda mais eficiente.
+
+---
+
+## 10) Gate de qualidade para release
+
+**O que será modificado**
+- Pipeline de validação para deploy previsível.
+
+**Arquivos principais**
+- `package.json`
+- (se existir) workflow de CI
+- `docs/05-maintenance-playbook.md`
+
+**Implementação (resumo)**
+- Criar script `type-check`.
+- Exigir `lint`, `type-check` e `build` antes de merge/deploy.
+- Incluir checklist de variáveis críticas de produção.
+
+**Melhora esperada**
+- Menos regressão em produção.
+- Processo de manutenção mais confiável para solo dev.
+
+---
+
+## Checklist de implementação por item
+
+Para cada item acima, confirmar:
+- [ ] Mudança aplicada nos arquivos listados
+- [ ] Teste funcional mínimo do fluxo afetado
+- [ ] `npm run lint` OK
+- [ ] `npm run type-check` OK
+- [ ] `npm run build` OK
+- [ ] Documentação atualizada quando necessário

--- a/docs/06-optimization-implementation-plan.md
+++ b/docs/06-optimization-implementation-plan.md
@@ -2,6 +2,22 @@
 
 Documento prático para implementação individual. Cada item descreve **o que mudar**, **onde mudar** e **qual ganho esperado**.
 
+## Versao separada por item
+
+Os itens deste plano foram organizados em arquivos separados em `docs/to-do`:
+
+- `docs/to-do/README.md`
+- `docs/to-do/01-autenticacao-admin-segura.md`
+- `docs/to-do/02-endurecer-autorizacao-trpc.md`
+- `docs/to-do/03-webhook-robusto-idempotente.md`
+- `docs/to-do/04-paginacao-filtros-servidor-admin.md`
+- `docs/to-do/05-prisma-unificado-cron.md`
+- `docs/to-do/06-cache-invalidacao-settings.md`
+- `docs/to-do/07-reducao-rerender-listeners.md`
+- `docs/to-do/08-consolidar-dominio-pagamento.md`
+- `docs/to-do/09-estrategia-imagens-lcp.md`
+- `docs/to-do/10-gate-qualidade-release.md`
+
 ---
 
 ## Ordem de execução recomendada

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,23 @@
+# Documentação do Projeto — Cachoeira das Araras
+
+Esta pasta reúne uma documentação prática para **uma pessoa desenvolvedora** manter e evoluir o site com segurança.
+
+## Ordem de leitura recomendada
+
+1. [`01-product-overview.md`](./01-product-overview.md)  
+   Visão geral do produto, público, fluxos principais e regras de negócio.
+2. [`02-architecture-and-stack.md`](./02-architecture-and-stack.md)  
+   Como o app é estruturado (Next.js App Router + tRPC + Prisma + Mercado Pago).
+3. [`03-routes-and-pages.md`](./03-routes-and-pages.md)  
+   Mapa das páginas públicas, admin e endpoints de API.
+4. [`04-data-model-and-settings.md`](./04-data-model-and-settings.md)  
+   Modelo de dados (Prisma), status do voucher e sistema de configurações dinâmicas.
+5. [`05-maintenance-playbook.md`](./05-maintenance-playbook.md)  
+   Guia de manutenção: tarefas comuns, checklists e pontos de atenção para mudanças futuras.
+
+## Objetivo desta documentação
+
+- Explicar **o que o app faz**.
+- Explicar **como ele funciona por dentro**.
+- Facilitar modificações futuras com baixo risco.
+- Ajudar a manter consistência entre front-end, regras de negócio e banco.

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,6 +14,8 @@ Esta pasta reúne uma documentação prática para **uma pessoa desenvolvedora**
    Modelo de dados (Prisma), status do voucher e sistema de configurações dinâmicas.
 5. [`05-maintenance-playbook.md`](./05-maintenance-playbook.md)  
    Guia de manutenção: tarefas comuns, checklists e pontos de atenção para mudanças futuras.
+6. [`06-optimization-implementation-plan.md`](./06-optimization-implementation-plan.md)  
+   Plano objetivo por item de otimização: o que mudar, onde mudar e ganho esperado.
 
 ## Objetivo desta documentação
 

--- a/docs/to-do/01-autenticacao-admin-segura.md
+++ b/docs/to-do/01-autenticacao-admin-segura.md
@@ -1,0 +1,32 @@
+# 01) Autenticacao admin segura
+
+## O que sera modificado
+
+- Substituir autenticacao por cookie simples/senha hardcoded por sessao segura.
+
+## Arquivos principais
+
+- `src/app/lib.ts`
+- `src/app/admin/layout.tsx`
+- `src/server/auth.ts`
+- (se necessario) middleware/guards para `/admin/*`
+
+## Implementacao (resumo)
+
+- Remover senha fixa e usar segredo em variavel de ambiente (hash).
+- Exigir sessao valida para acesso admin.
+- Configurar cookie de sessao com `httpOnly`, `secure`, `sameSite`.
+
+## Melhora esperada
+
+- Reduz risco de acesso indevido ao admin.
+- Maior seguranca de producao e governanca de acesso.
+
+## Checklist do item
+
+- [ ] Mudanca aplicada nos arquivos listados
+- [ ] Teste funcional minimo do fluxo afetado
+- [ ] `pnpm lint` OK
+- [ ] `pnpm type-check` OK
+- [ ] `pnpm build` OK
+- [ ] Documentacao atualizada quando necessario

--- a/docs/to-do/02-endurecer-autorizacao-trpc.md
+++ b/docs/to-do/02-endurecer-autorizacao-trpc.md
@@ -1,0 +1,32 @@
+# 02) Endurecer autorizacao de tRPC
+
+## O que sera modificado
+
+- Procedures sensiveis deixarao de ser publicas.
+
+## Arquivos principais
+
+- `src/server/api/trpc.ts`
+- `src/server/api/routers/voucher.ts`
+- `src/server/api/routers/notification.ts`
+- `src/server/api/routers/settings.ts`
+
+## Implementacao (resumo)
+
+- Migrar mutacoes sensiveis para `protectedProcedure`.
+- Manter publicas apenas operacoes necessarias ao fluxo de compra.
+- Padronizar retorno de erro com `TRPCError`.
+
+## Melhora esperada
+
+- Menor superficie de ataque.
+- Menor chance de alteracao indevida de vouchers/settings.
+
+## Checklist do item
+
+- [ ] Mudanca aplicada nos arquivos listados
+- [ ] Teste funcional minimo do fluxo afetado
+- [ ] `pnpm lint` OK
+- [ ] `pnpm type-check` OK
+- [ ] `pnpm build` OK
+- [ ] Documentacao atualizada quando necessario

--- a/docs/to-do/03-webhook-robusto-idempotente.md
+++ b/docs/to-do/03-webhook-robusto-idempotente.md
@@ -1,0 +1,31 @@
+# 03) Webhook robusto e idempotente
+
+## O que sera modificado
+
+- Validacao de webhook com regras estritas e sem fallback inseguro.
+
+## Arquivos principais
+
+- `src/app/api/webhook/route.ts`
+- `src/server/api/routers/voucher.ts` (suporte a idempotencia se necessario)
+
+## Implementacao (resumo)
+
+- Remover fallback de segredo (`your-secret-key`).
+- Validar obrigatoriedade de headers e parametros.
+- Garantir processamento idempotente por `payment_id`/`code`.
+- Logar eventos e falhas de forma rastreavel.
+
+## Melhora esperada
+
+- Menor risco de fraude/processamento duplo.
+- Fluxo de pagamento mais estavel em producao.
+
+## Checklist do item
+
+- [ ] Mudanca aplicada nos arquivos listados
+- [ ] Teste funcional minimo do fluxo afetado
+- [ ] `pnpm lint` OK
+- [ ] `pnpm type-check` OK
+- [ ] `pnpm build` OK
+- [ ] Documentacao atualizada quando necessario

--- a/docs/to-do/04-paginacao-filtros-servidor-admin.md
+++ b/docs/to-do/04-paginacao-filtros-servidor-admin.md
@@ -1,0 +1,32 @@
+# 04) Paginacao e filtros no servidor (admin)
+
+## O que sera modificado
+
+- Listagens admin deixarao de carregar tudo no client.
+
+## Arquivos principais
+
+- `src/server/api/routers/voucher.ts`
+- `src/app/admin/dashboard/vouchers/page.tsx`
+- `src/app/admin/tabela/data-table.tsx`
+- `src/app/admin/tabela/voucher-table.tsx`
+
+## Implementacao (resumo)
+
+- Criar query paginada (`take/skip` ou cursor) com filtros (status, busca, periodo).
+- Retornar total e pagina atual.
+- Adaptar UI para paginacao server-side.
+
+## Melhora esperada
+
+- Escala melhor com crescimento de dados.
+- Menor uso de memoria e CPU no navegador.
+
+## Checklist do item
+
+- [ ] Mudanca aplicada nos arquivos listados
+- [ ] Teste funcional minimo do fluxo afetado
+- [ ] `pnpm lint` OK
+- [ ] `pnpm type-check` OK
+- [ ] `pnpm build` OK
+- [ ] Documentacao atualizada quando necessario

--- a/docs/to-do/05-prisma-unificado-cron.md
+++ b/docs/to-do/05-prisma-unificado-cron.md
@@ -1,0 +1,29 @@
+# 05) Prisma unificado no cron
+
+## O que sera modificado
+
+- Cron deixara de instanciar `PrismaClient` localmente.
+
+## Arquivos principais
+
+- `src/app/api/cron/route.ts`
+- `src/server/db.ts`
+
+## Implementacao (resumo)
+
+- Reutilizar cliente Prisma singleton do projeto.
+- Registrar quantos vouchers foram atualizados/deletados em cada execucao.
+
+## Melhora esperada
+
+- Menos risco de conexoes excedentes.
+- Operacao de cron mais previsivel.
+
+## Checklist do item
+
+- [ ] Mudanca aplicada nos arquivos listados
+- [ ] Teste funcional minimo do fluxo afetado
+- [ ] `pnpm lint` OK
+- [ ] `pnpm type-check` OK
+- [ ] `pnpm build` OK
+- [ ] Documentacao atualizada quando necessario

--- a/docs/to-do/06-cache-invalidacao-settings.md
+++ b/docs/to-do/06-cache-invalidacao-settings.md
@@ -1,0 +1,31 @@
+# 06) Cache/invalidacao para settings
+
+## O que sera modificado
+
+- Politica explicita para reduzir leituras repetidas de configuracao.
+
+## Arquivos principais
+
+- `src/lib/settings.ts`
+- `src/server/api/routers/settings.ts`
+- `src/app/admin/dashboard/configuracoes/actions.ts`
+
+## Implementacao (resumo)
+
+- Adicionar cache curto para `getAllSettings`.
+- Invalidar cache apos update de configuracao.
+- Padronizar uso de settings no front.
+
+## Melhora esperada
+
+- Menor latencia e menos carga no banco.
+- Atualizacao consistente de regras operacionais.
+
+## Checklist do item
+
+- [ ] Mudanca aplicada nos arquivos listados
+- [ ] Teste funcional minimo do fluxo afetado
+- [ ] `pnpm lint` OK
+- [ ] `pnpm type-check` OK
+- [ ] `pnpm build` OK
+- [ ] Documentacao atualizada quando necessario

--- a/docs/to-do/07-reducao-rerender-listeners.md
+++ b/docs/to-do/07-reducao-rerender-listeners.md
@@ -1,0 +1,30 @@
+# 07) Reducao de re-render e listeners frageis
+
+## O que sera modificado
+
+- Ajustes em componentes com risco de re-render e listeners globais.
+
+## Arquivos principais
+
+- `src/app/_components/voucher-form.tsx`
+- `src/app/admin/tabela/voucher-table.tsx`
+
+## Implementacao (resumo)
+
+- Remover `window.onresize` global e usar `useEffect` com cleanup.
+- Estabilizar dependencias de `useEffect` no formulario.
+- Extrair hooks utilitarios reutilizaveis.
+
+## Melhora esperada
+
+- Menos bugs de UI e melhor fluidez.
+- Comportamento mais previsivel em mobile/desktop.
+
+## Checklist do item
+
+- [ ] Mudanca aplicada nos arquivos listados
+- [ ] Teste funcional minimo do fluxo afetado
+- [ ] `pnpm lint` OK
+- [ ] `pnpm type-check` OK
+- [ ] `pnpm build` OK
+- [ ] Documentacao atualizada quando necessario

--- a/docs/to-do/08-consolidar-dominio-pagamento.md
+++ b/docs/to-do/08-consolidar-dominio-pagamento.md
@@ -1,0 +1,32 @@
+# 08) Consolidar dominio de pagamento
+
+## O que sera modificado
+
+- Remover duplicidade e padronizar nomenclatura/fluxo.
+
+## Arquivos principais
+
+- `src/server/api/routers/mercadopago.ts`
+- `src/app/(client)/pagamento/page.tsx`
+- `src/app/(client)/pagamento/aprovado/page.tsx`
+- `src/app/(client)/voucher/page.tsx`
+- `src/lib/mercadopago/*`
+
+## Implementacao (resumo)
+
+- Corrigir typo `getPrefence` e eliminar duplicacoes.
+- Centralizar fetch e normalizacao de `payment/preference` em servico unico.
+
+## Melhora esperada
+
+- Menor custo de manutencao.
+- Menos inconsistencias entre paginas de pagamento.
+
+## Checklist do item
+
+- [ ] Mudanca aplicada nos arquivos listados
+- [ ] Teste funcional minimo do fluxo afetado
+- [ ] `pnpm lint` OK
+- [ ] `pnpm type-check` OK
+- [ ] `pnpm build` OK
+- [ ] Documentacao atualizada quando necessario

--- a/docs/to-do/09-estrategia-imagens-lcp.md
+++ b/docs/to-do/09-estrategia-imagens-lcp.md
@@ -1,0 +1,32 @@
+# 09) Estrategia de imagens e LCP
+
+## O que sera modificado
+
+- Revisar uso de `images.unoptimized` global e pipeline de assets.
+
+## Arquivos principais
+
+- `next.config.js`
+- `src/app/_components/image_carousel.tsx`
+- `src/app/_components/swiper-carousel/mini-image-carousel.tsx`
+- `public/images/*`
+
+## Implementacao (resumo)
+
+- Avaliar otimizacao seletiva de imagens.
+- Padronizar dimensoes, compressao e formatos modernos.
+- Manter prioridade apenas para imagens criticas.
+
+## Melhora esperada
+
+- Melhor LCP e experiencia inicial do usuario.
+- Uso de banda mais eficiente.
+
+## Checklist do item
+
+- [ ] Mudanca aplicada nos arquivos listados
+- [ ] Teste funcional minimo do fluxo afetado
+- [ ] `pnpm lint` OK
+- [ ] `pnpm type-check` OK
+- [ ] `pnpm build` OK
+- [ ] Documentacao atualizada quando necessario

--- a/docs/to-do/10-gate-qualidade-release.md
+++ b/docs/to-do/10-gate-qualidade-release.md
@@ -1,0 +1,31 @@
+# 10) Gate de qualidade para release
+
+## O que sera modificado
+
+- Pipeline de validacao para deploy previsivel.
+
+## Arquivos principais
+
+- `package.json`
+- (se existir) workflow de CI
+- `docs/05-maintenance-playbook.md`
+
+## Implementacao (resumo)
+
+- Criar script `type-check`.
+- Exigir `lint`, `type-check` e `build` antes de merge/deploy.
+- Incluir checklist de variaveis criticas de producao.
+
+## Melhora esperada
+
+- Menos regressao em producao.
+- Processo de manutencao mais confiavel para solo dev.
+
+## Checklist do item
+
+- [ ] Mudanca aplicada nos arquivos listados
+- [ ] Teste funcional minimo do fluxo afetado
+- [ ] `pnpm lint` OK
+- [ ] `pnpm type-check` OK
+- [ ] `pnpm build` OK
+- [ ] Documentacao atualizada quando necessario

--- a/docs/to-do/README.md
+++ b/docs/to-do/README.md
@@ -1,0 +1,16 @@
+# To-do — Implementacao das Otimizacoes
+
+Este diretorio separa o plano de implementacao por item para facilitar execucao, acompanhamento e priorizacao.
+
+## Ordem recomendada
+
+1. [01-autenticacao-admin-segura](./01-autenticacao-admin-segura.md)
+2. [02-endurecer-autorizacao-trpc](./02-endurecer-autorizacao-trpc.md)
+3. [03-webhook-robusto-idempotente](./03-webhook-robusto-idempotente.md)
+4. [04-paginacao-filtros-servidor-admin](./04-paginacao-filtros-servidor-admin.md)
+5. [05-prisma-unificado-cron](./05-prisma-unificado-cron.md)
+6. [06-cache-invalidacao-settings](./06-cache-invalidacao-settings.md)
+7. [07-reducao-rerender-listeners](./07-reducao-rerender-listeners.md)
+8. [08-consolidar-dominio-pagamento](./08-consolidar-dominio-pagamento.md)
+9. [09-estrategia-imagens-lcp](./09-estrategia-imagens-lcp.md)
+10. [10-gate-qualidade-release](./10-gate-qualidade-release.md)


### PR DESCRIPTION
### Motivation
- Make it easy for a single developer to understand, operate and evolve the site by moving documentation into small, focused files that explain product flows, architecture, routes, data model and maintenance tasks.
- Reduce friction when changing runtime behavior (prices, flags, cron, webhooks) by documenting where the logic lives and which files to edit.

### Description
- Add a docs hub at `docs/README.md` and five focused docs: `docs/01-product-overview.md`, `docs/02-architecture-and-stack.md`, `docs/03-routes-and-pages.md`, `docs/04-data-model-and-settings.md`, and `docs/05-maintenance-playbook.md` describing product scope, architecture, routes, Prisma model and maintenance playbook respectively.
- Replace the root `README.md` with a concise entry that points to the new `docs/` folder and includes recommended commands to run locally.
- All changes are documentation-only and do not modify runtime logic or application source files.

### Testing
- Ran `npm run lint`, which failed due to missing required environment variables (`NEXTAUTH_SECRET`, `NEXTAUTH_URL`, `DATABASE_URL`, `URL`, `MERCADOPAGO_TOKEN`, `WEBHOOK_URL`, `CRON_SECRET`) in this environment.
- Attempted `npm run type-check`, which failed because a `type-check` script is not present in `package.json`.
- Ran `npm run build`, which failed for the same missing environment variables as the lint step.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d32c78fee4832bb4989616667f50ea)